### PR TITLE
CI: GHA: Update optaplanner references

### DIFF
--- a/.ci/buildchain-config.yaml
+++ b/.ci/buildchain-config.yaml
@@ -25,7 +25,7 @@ default:
         docker system prune -f
 
 build:
-  - project: kiegroup/optaplanner
+  - project: apache/incubator-kie-optaplanner
     build-command:
       before:
         upstream: |

--- a/.ci/buildchain-project-dependencies.yaml
+++ b/.ci/buildchain-project-dependencies.yaml
@@ -1,9 +1,9 @@
 version: "2.1"
 dependencies:
-  - project: kiegroup/optaplanner
+  - project: apache/incubator-kie-optaplanner
   - project: kiegroup/optaplanner-quickstarts
     dependencies:
-      - project: kiegroup/optaplanner
+      - project: apache/incubator-kie-optaplanner
     mapping:
       dependencies:
         default:

--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -25,11 +25,11 @@ build:
       upstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_drools }}
         bash -c "${{ env.ALIGN_QUARKUS }} -pl :drools-build-parent ; set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_drools }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/drools.maven.log"
-  - project: kiegroup/optaplanner
+  - project: apache/incubator-kie-optaplanner
     build-command:
       current: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_optaplanner }}
-        bash -c "set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_optaplanner }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/optaplanner.maven.log"
+        bash -c "set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_apache_incubator_kie_optaplanner }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/incubator-kie-optaplanner.maven.log"
   - project: kiegroup/optaplanner-quickstarts
     build-command:
       downstream: |

--- a/.ci/project-dependencies-rhbop.yaml
+++ b/.ci/project-dependencies-rhbop.yaml
@@ -3,13 +3,13 @@ version: "2.1"
 dependencies:
   - project: kiegroup/drools
 
-  - project: kiegroup/optaplanner
+  - project: apache/incubator-kie-optaplanner
     dependencies:
       - project: kiegroup/drools
 
   - project: kiegroup/optaplanner-quickstarts
     dependencies:
-      - project: kiegroup/optaplanner
+      - project: apache/incubator-kie-optaplanner
     mapping:
       dependencies:
         default:

--- a/.ci/pull-request-config-rhbop.yaml
+++ b/.ci/pull-request-config-rhbop.yaml
@@ -24,7 +24,7 @@ build:
           export DROOLS_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout`
           echo "DROOLS_VERSION=${{ env.DROOLS_VERSION }}"
 
-  - project: kiegroup/optaplanner
+  - project: apache/incubator-kie-optaplanner
     build-command: 
       current: mvn clean install -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS }} -Dversion.org.drools=${{ env.DROOLS_VERSION }}
       upstream: mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM }} -Dversion.org.drools=${{ env.DROOLS_VERSION }}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ changes that span multiple kiegroup repositories and depend on each other. -->
 <!-- Example:
 - https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
 - https://github.com/kiegroup/drools/pull/3000
-- https://github.com/kiegroup/optaplanner/pull/899
+- https://github.com/apache/incubator-kie-optaplanner/pull/899
 - etc.
 -->
 
@@ -106,7 +106,7 @@ How to retest this PR or trigger a specific build:
 
 ### CI Status
 
- You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
+ You can check OptaPlanner repositories CI status from [Chain Status webpage](https://apache.github.io/incubator-kie-optaplanner/).
 
 <details>
 <summary>

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build Chain
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/incubator-kie-optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           flow-type: full-downstream

--- a/.github/workflows/generate_status_page_data.yaml
+++ b/.github/workflows/generate_status_page_data.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 * * * *'
 jobs:
   generate-status-page-data:
-    if: github.repository == 'kiegroup/optaplanner'
+    if: github.repository == 'apache/incubator-kie-optaplanner'
     concurrency:
       group: generate-status-page-data
       cancel-in-progress: true
@@ -20,7 +20,7 @@ jobs:
       - name: Generate status page data
         uses: kiegroup/chain-status/.ci/actions/generate-data@main
         with:
-          definition-file: https://raw.githubusercontent.com/kiegroup/optaplanner/main/.ci/builchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/apache/incubator-kie-optaplanner/main/.ci/builchain-config.yaml
           title: Pull Request Status
           subtitle: OptaPlanner organization repositories CI Status
           base-branch-filter: main,8\.*

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -20,6 +20,6 @@ jobs:
       uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
       with:
         project: optaplanner
-        main-config-file-repo: kiegroup/optaplanner
+        main-config-file-repo: apache/incubator-kie-optaplanner
         main-config-file-path: .ci/jenkins/config/main.yaml
-        branch-config-file-repo: kiegroup/optaplanner
+        branch-config-file-repo: apache/incubator-kie-optaplanner

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,9 +59,9 @@ jobs:
           # maven-assembly-plugin occasionally fails on heap space when building the ZIP in optaplanner-docs
           MAVEN_OPTS: "-Xmx2048m"
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/incubator-kie-optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
-          starting-project: kiegroup/optaplanner
+          starting-project: apache/incubator-kie-optaplanner
           flow-type: ${{ env.FLOW_TYPE }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Surefire Report

--- a/.github/workflows/rhbop_productized_pull_request.yml
+++ b/.github/workflows/rhbop_productized_pull_request.yml
@@ -48,7 +48,7 @@ jobs:
           # maven-assembly-plugin occasionally fails on heap space when building the ZIP in optaplanner-docs
           MAVEN_OPTS: "-Xmx2048m"
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/optaplanner/${BRANCH:main}/.ci/pull-request-config-rhbop.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/incubator-kie-optaplanner/${BRANCH:main}/.ci/pull-request-config-rhbop.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Surefire Report


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
