### PR TITLE
Update `kiegroup` repository references to `apache`

### DIFF
--- a/.ci/buildchain-config.yaml
+++ b/.ci/buildchain-config.yaml
@@ -25,7 +25,7 @@ default:
         docker system prune -f
 
 build:
-  - project: kiegroup/optaplanner
+  - project: apache/optaplanner
     build-command:
       before:
         upstream: |
@@ -35,7 +35,7 @@ build:
       upstream: |
         mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM }}
 
-  - project: kiegroup/optaplanner-quickstarts
+  - project: apache/optaplanner-quickstarts
     build-command:
       current: |
         mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAPLANNER_QUICKSTARTS_BUILD_MVN_OPTS }}

--- a/.ci/buildchain-config.yaml
+++ b/.ci/buildchain-config.yaml
@@ -25,7 +25,7 @@ default:
         docker system prune -f
 
 build:
-  - project: apache/optaplanner
+  - project: apache/incubator-kie-optaplanner
     build-command:
       before:
         upstream: |
@@ -35,7 +35,7 @@ build:
       upstream: |
         mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM }}
 
-  - project: apache/optaplanner-quickstarts
+  - project: apache/incubator-kie-optaplanner-quickstarts
     build-command:
       current: |
         mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAPLANNER_QUICKSTARTS_BUILD_MVN_OPTS }}

--- a/.ci/buildchain-project-dependencies.yaml
+++ b/.ci/buildchain-project-dependencies.yaml
@@ -1,9 +1,9 @@
 version: "2.1"
 dependencies:
-  - project: kiegroup/optaplanner
-  - project: kiegroup/optaplanner-quickstarts
+  - project: apache/optaplanner
+  - project: apache/optaplanner-quickstarts
     dependencies:
-      - project: kiegroup/optaplanner
+      - project: apache/optaplanner
     mapping:
       dependencies:
         default:

--- a/.ci/buildchain-project-dependencies.yaml
+++ b/.ci/buildchain-project-dependencies.yaml
@@ -1,9 +1,9 @@
 version: "2.1"
 dependencies:
-  - project: apache/optaplanner
-  - project: apache/optaplanner-quickstarts
+  - project: apache/incubator-kie-optaplanner
+  - project: apache/incubator-kie-optaplanner-quickstarts
     dependencies:
-      - project: apache/optaplanner
+      - project: apache/incubator-kie-optaplanner
     mapping:
       dependencies:
         default:

--- a/.ci/environments/common/update_quarkus.sh
+++ b/.ci/environments/common/update_quarkus.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 mvn_cmd="mvn ${BUILD_MVN_OPTS:-} ${BUILD_MVN_OPTS_QUARKUS_UPDATE:-}"
 
-source <(curl -s https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/install_quarkus.sh)
+source <(curl -s https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/install_quarkus.sh)
 
 echo "Update project with Quarkus version ${QUARKUS_VERSION}"
 

--- a/.ci/environments/common/update_quarkus.sh
+++ b/.ci/environments/common/update_quarkus.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 mvn_cmd="mvn ${BUILD_MVN_OPTS:-} ${BUILD_MVN_OPTS_QUARKUS_UPDATE:-}"
 
-source <(curl -s https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/install_quarkus.sh)
+source <(curl -s https://raw.githubusercontent.com/apache/incubator-kie-kogito-pipelines/main/dsl/seed/scripts/install_quarkus.sh)
 
 echo "Update project with Quarkus version ${QUARKUS_VERSION}"
 

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
     options {
         timestamps()
-        timeout(time: '720', unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
     }
     environment {
         BUILDCHAIN_PROJECT = 'apache/optaplanner'

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
     environment {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-optaplanner'
-        BUILDCHAIN_CONFIG_REPO = 'optaplanner'
+        BUILDCHAIN_CONFIG_REPO = 'incubator-kie-optaplanner'
         BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config.yaml'
 
         ENABLE_SONARCLOUD = 'true'

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         timeout(time: '720', unit: 'MINUTES')
     }
     environment {
-        BUILDCHAIN_PROJECT = 'kiegroup/optaplanner'
+        BUILDCHAIN_PROJECT = 'apache/optaplanner'
         BUILDCHAIN_CONFIG_REPO = 'optaplanner'
         BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config.yaml'
 
@@ -25,7 +25,7 @@ pipeline {
                 script {
                     // load `pr_check.groovy` file from kogito-pipelines:main
                     dir('kogito-pipelines') {
-                        checkout(githubscm.resolveRepository('kogito-pipelines', 'kiegroup', 'apache_migration', false, 'kie-ci')) // TODO to change back to kiegroup:main
+                        checkout(githubscm.resolveRepository('kogito-pipelines', 'apache', 'main', false, 'ASF_Cloudbees_Jenkins_ci-builds'))
                         pr_check_script = load 'dsl/scripts/pr_check.groovy'
                     }
                 }

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         timeout(time: 360, unit: 'MINUTES')
     }
     environment {
-        BUILDCHAIN_PROJECT = 'apache/optaplanner'
+        BUILDCHAIN_PROJECT = 'apache/incubator-kie-optaplanner'
         BUILDCHAIN_CONFIG_REPO = 'optaplanner'
         BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config.yaml'
 

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -1,0 +1,44 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+pr_check_script = null
+
+pipeline {
+    agent {
+        label 'ubuntu'
+    }
+    options {
+        timestamps()
+        timeout(time: '720', unit: 'MINUTES')
+    }
+    environment {
+        BUILDCHAIN_PROJECT = 'kiegroup/optaplanner'
+        BUILDCHAIN_CONFIG_REPO = 'optaplanner'
+        BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config.yaml'
+
+        ENABLE_SONARCLOUD = 'true'
+        SONARCLOUD_ANALYSIS_MVN_OPTS = '-Dsonar.projectKey=org.optaplanner:optaplanner'
+        OPTAPLANNER_BUILD_MVN_OPTS = '-Prun-code-coverage'
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    // load `pr_check.groovy` file from kogito-pipelines:main
+                    dir('kogito-pipelines') {
+                        checkout(githubscm.resolveRepository('kogito-pipelines', 'kiegroup', 'apache_migration', false, 'kie-ci')) // TODO to change back to kiegroup:main
+                        pr_check_script = load 'dsl/scripts/pr_check.groovy'
+                    }
+                }
+            }
+        }
+        stage('PR check') {
+            steps {
+                script {
+                    dir('kogito-pipelines') {
+                        pr_check_script.launch()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                 script {
                     // load `pr_check.groovy` file from kogito-pipelines:main
                     dir('kogito-pipelines') {
-                        checkout(githubscm.resolveRepository('kogito-pipelines', 'apache', 'main', false, 'ASF_Cloudbees_Jenkins_ci-builds'))
+                        checkout(githubscm.resolveRepository('incubator-kie-kogito-pipelines', 'apache', 'main', false, 'ASF_Cloudbees_Jenkins_ci-builds'))
                         pr_check_script = load 'dsl/scripts/pr_check.groovy'
                     }
                 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -307,7 +307,7 @@ void checkoutRepo(String repo, String dirName = repo) {
     dir(dirName) {
         deleteDir()
         if (params.PR_TARGET_BRANCH) {
-            githubscm.checkoutIfExists(repo, getGitAuthor(), getBuildBranch(), 'kiegroup', getFallbackBranch(repo), true)
+            githubscm.checkoutIfExists(repo, getGitAuthor(), getBuildBranch(), 'apache', getFallbackBranch(repo), true)
         } else {
             checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBuildBranch(), false))
         }
@@ -318,7 +318,7 @@ void checkoutQuickstarts(String dirName = quickstartsRepository) {
     dir(dirName) {
         deleteDir()
         if (params.PR_TARGET_BRANCH) {
-            githubscm.checkoutIfExists(quickstartsRepository, getGitAuthor(), getBuildBranch(), 'kiegroup', getQuickStartsBranch(), true)
+            githubscm.checkoutIfExists(quickstartsRepository, getGitAuthor(), getBuildBranch(), 'apache', getQuickStartsBranch(), true)
         } else {
             checkout(githubscm.resolveRepository(quickstartsRepository, getGitAuthor(), getQuickStartsBranch(), false))
         }
@@ -326,7 +326,7 @@ void checkoutQuickstarts(String dirName = quickstartsRepository) {
 }
 
 String getFallbackBranch(String repo) {
-    def repositoryScm = githubscm.getRepositoryScm(repo, 'kiegroup', params.PR_TARGET_BRANCH)
+    def repositoryScm = githubscm.getRepositoryScm(repo, 'apache', params.PR_TARGET_BRANCH)
     return repositoryScm ? params.PR_TARGET_BRANCH : 'main'
 }
 
@@ -439,7 +439,7 @@ boolean shouldDeployToRepository() {
 }
 
 boolean isNotTestingBuild() {
-    return getGitAuthor() == 'kiegroup'
+    return getGitAuthor() == 'apache'
 }
 
 boolean isRelease() {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -14,12 +14,10 @@ imageUtils = null
 
 pipeline {
     agent {
-        label 'ubuntu'
-    }
-
-    tools {
-        maven env.BUILD_MAVEN_TOOL
-        jdk env.BUILD_JDK_TOOL
+        docker { 
+            image env.AGENT_DOCKER_BUILDER_IMAGE
+            args env.AGENT_DOCKER_BUILDER_ARGS
+        }
     }
 
     options {
@@ -28,21 +26,13 @@ pipeline {
         disableConcurrentBuilds(abortPrevious: true)
     }
 
-    // parameters {
-    // For parameters, check into .jenkins/dsl/jobs.groovy file
-    // }
-
     environment {
-        // Some generated env is also defined into .jenkins/dsl/jobs.groovy file
-
         OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
-
-        MAVEN_OPTS = '-Xms1024m -Xmx4g'
 
         PR_BRANCH_HASH = "${util.generateHash(10)}"
 
         // Maven configuration
-        MAVEN_DEPLOY_LOCAL_DIR = "${WORKSPACE}/maven_deploy_dir"
+        MAVEN_DEPLOY_LOCAL_DIR = "/tmp/maven_deploy_dir"
     }
 
     stages {
@@ -196,9 +186,6 @@ pipeline {
         stage('Stage artifacts') {
             when {
                 expression { return shouldStageArtifacts() }
-            }
-            tools {
-                jdk 'kie-jdk11'
             }
             steps {
                 script {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -7,8 +7,8 @@ import org.kie.jenkins.MavenStagingHelper
 
 deployProperties = [:]
 
-optaplannerRepository = 'optaplanner'
-quickstartsRepository = 'optaplanner-quickstarts'
+optaplannerRepository = 'incubator-kie-optaplanner'
+quickstartsRepository = 'incubator-kie-optaplanner-quickstarts'
 
 imageUtils = null
 

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -13,12 +13,10 @@ imageUtils = null
 
 pipeline {
     agent {
-        label 'ubuntu'
-    }
-
-    tools {
-        maven env.BUILD_MAVEN_TOOL
-        jdk env.BUILD_JDK_TOOL
+        docker { 
+            image env.AGENT_DOCKER_BUILDER_IMAGE
+            args env.AGENT_DOCKER_BUILDER_ARGS
+        }
     }
 
     options {
@@ -27,13 +25,7 @@ pipeline {
         disableConcurrentBuilds(abortPrevious: true)
     }
 
-    // parameters {
-    // For parameters, check into .jenkins/dsl/jobs.groovy file
-    // }
-
     environment {
-        // Some generated env is also defined into .jenkins/dsl/jobs.groovy file
-
         OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
         PR_BRANCH_HASH = "${util.generateHash(10)}"

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -6,8 +6,8 @@ import org.kie.jenkins.MavenCommand
 deployProperties = [:]
 pipelineProperties = [:]
 
-String optaplannerRepository = 'optaplanner'
-String quickstartsRepository = 'optaplanner-quickstarts'
+String optaplannerRepository = 'incubator-kie-optaplanner'
+String quickstartsRepository = 'incubator-kie-optaplanner-quickstarts'
 
 imageUtils = null
 

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -173,7 +173,7 @@ String getParamOrDeployProperty(String paramKey, String deployPropertyKey) {
 //////////////////////////////////////////////////////////////////////////////
 
 boolean isNotTestingBuild() {
-    return getGitAuthor() == 'kiegroup'
+    return getGitAuthor() == 'apache'
 }
 
 String getProjectVersion() {

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -5,12 +5,10 @@ import org.kie.jenkins.MavenCommand
 
 pipeline {
     agent {
-        label 'ubuntu'
-    }
-
-    tools {
-        maven env.BUILD_MAVEN_TOOL
-        jdk env.BUILD_JDK_TOOL
+        docker { 
+            image env.AGENT_DOCKER_BUILDER_IMAGE
+            args env.AGENT_DOCKER_BUILDER_ARGS
+        }
     }
 
     options {
@@ -18,17 +16,8 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
     }
 
-    // parameters {
-    // For parameters, check into ./dsl/jobs.groovy file
-    // }
-
     environment {
-        // Static env is defined into ./dsl/jobs.groovy file
-
         OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
-
-        // Keep here for visitibility
-        MAVEN_OPTS = '-Xms1024m -Xmx4g'
 
         BRANCH_HASH = "${util.generateHash(10)}"
     }

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -2,7 +2,7 @@
 
 import org.kie.jenkins.MavenCommand
 
-optaplannerRepo = 'optaplanner'
+optaplannerRepo = 'incubator-kie-optaplanner'
 
 pipeline {
     agent {

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -6,22 +6,17 @@ optaplannerRepo = 'optaplanner'
 
 pipeline {
     agent {
-        label 'ubuntu'
-    }
-    tools {
-        maven env.BUILD_MAVEN_TOOL
-        jdk env.BUILD_JDK_TOOL
+        docker { 
+            image env.AGENT_DOCKER_BUILDER_IMAGE
+            args env.AGENT_DOCKER_BUILDER_ARGS
+        }
     }
     options {
         timestamps()
         timeout(time: 3, unit: 'DAYS') // Turtle tests take ~2 days to complete.
         disableConcurrentBuilds(abortPrevious: true)
     }
-    // parameters {
-    // For parameters, check the .jenkins/dsl/jobs.groovy file.
-    // }
     environment {
-        MAVEN_OPTS = '-Xms1024m -Xmx4g'
         // Contains the email address of the team's Zulip channel.
         OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
     }

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -25,10 +25,14 @@ disable:
   triggers: true # TODO to set back
 repositories:
 - name: incubator-kie-optaplanner
+  job_display_name: optaplanner
 - name: incubator-kie-optaplanner-quickstarts
+  job_display_name: optaplanner-quickstarts
   branch: 8.x
 - name: incubator-kie-optaplanner-website
+  job_display_name: optaplanner-website
 - name: incubator-kie-kie-benchmarks
+  job_display_name: kie-benchmarks
   author:
     name: radtriste # TODO set back. Could not push to kiegroup
 git:

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -24,10 +24,11 @@ environments:
 disable:
   triggers: true # TODO to set back
 repositories:
-- name: optaplanner
-- name: optaplanner-quickstarts
-- name: optaplanner-website
-- name: kie-benchmarks
+- name: incubator-kie-optaplanner
+- name: incubator-kie-optaplanner-quickstarts
+  branch: 8.x
+- name: incubator-kie-optaplanner-website
+- name: incubator-kie-kie-benchmarks
   author:
     name: radtriste # TODO set back. Could not push to kiegroup
 git:
@@ -48,7 +49,7 @@ git:
   jenkins_config_path: .ci/jenkins
 buildchain_config:
   git:
-    repository: optaplanner
+    repository: incubator-kie-optaplanner
     file_path: .ci/buildchain-config.yaml
 maven:
   settings_file_id: kie-release-settings

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -32,9 +32,11 @@ repositories:
     name: radtriste # TODO set back. Could not push to kiegroup
 git:
   author:
-    name: kiegroup
-    credentials_id: kie-ci5
-    token_credentials_id: kie-ci5-token
+    name: apache
+    # Taken from https://ci-builds.apache.org/credentials/
+    # Need to be verified
+    credentials_id: 399061d0-5ab5-4142-a186-a52081fef742
+    token_credentials_id: ci-builds
   fork_author:
     name: kie-ci
     credentials_id: kie-ci

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -29,8 +29,9 @@ repositories:
 - name: incubator-kie-optaplanner-quickstarts
   job_display_name: optaplanner-quickstarts
   branch: 8.x
-- name: incubator-kie-optaplanner-website
-  job_display_name: optaplanner-website
+# Not migrated to Apache yet
+# - name: incubator-kie-optaplanner-website
+#   job_display_name: optaplanner-website
 - name: incubator-kie-kie-benchmarks
   job_display_name: kie-benchmarks
   author:

--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -10,16 +10,16 @@ ecosystem:
     - kie-benchmarks.*
 git:
   branches:
-  - name: apache_migration
+  - name: main
     main_branch: true
 seed:
   config_file:
     git:
       repository: optaplanner
       author:
-        name: kiegroup
+        name: apache
         credentials_id: kie-ci5
-      branch: apache_migration
+      branch: main
     path: .ci/jenkins/config/branch.yaml
 jenkins:
   email_creds_id: KOGITO_CI_NOTIFICATION_EMAILS

--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -3,11 +3,12 @@ ecosystem:
   projects:
   - name: optaplanner
     regexs:
+    - incubator-kie-opta.*
     - opta.*
   - name: kie-benchmarks
     ignore_release: true
     regexs:
-    - kie-benchmarks.*
+    - incubator-kie-kie-benchmarks.*
 git:
   branches:
   - name: main
@@ -15,7 +16,7 @@ git:
 seed:
   config_file:
     git:
-      repository: optaplanner
+      repository: incubator-kie-optaplanner
       author:
         name: apache
         credentials_id: kie-ci5

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -2,10 +2,10 @@
 * This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
 * needed by the Kogito pipelines.
 *
-* The main part of Jenkins job generation is defined into the https://github.com/kiegroup/kogito-pipelines repository.
+* The main part of Jenkins job generation is defined into the https://github.com/apache/kogito-pipelines repository.
 *
 * This file is making use of shared libraries defined in
-* https://github.com/kiegroup/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+* https://github.com/apache/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
 import org.kie.jenkins.jobdsl.model.JenkinsFolder

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -236,7 +236,6 @@ void createSetupBranchJob() {
     def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner', JobType.SETUP_BRANCH, "${jenkins_path}/Jenkinsfile.setup-branch", 'OptaPlanner Setup Branch')
     JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
-        REPO_NAME: 'optaplanner',
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -192,9 +192,7 @@ Map getMultijobPRConfig(JenkinsFolder jobFolder) {
 }
 
 // Optaplanner PR checks
-// Deactivated due to ghprb not available on Apache Jenkins
-// TODO create PR job with branch source plugin
-// KogitoJobUtils.createAllEnvironmentsPerRepoPRJobs(this) { jobFolder -> getMultijobPRConfig(jobFolder) }
+Utils.isMainBranch(this) && KogitoJobTemplate.createPullRequestMultibranchPipelineJob(this, "${jenkins_path}/Jenkinsfile")
 
 // Setup branch branch
 createSetupBranchJob()

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -2,10 +2,10 @@
 * This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
 * needed by the Kogito pipelines.
 *
-* The main part of Jenkins job generation is defined into the https://github.com/apache/kogito-pipelines repository.
+* The main part of Jenkins job generation is defined into the https://github.com/apache/incubator-kie-kogito-pipelines repository.
 *
 * This file is making use of shared libraries defined in
-* https://github.com/apache/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+* https://github.com/apache/incubator-kie-kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
 import org.kie.jenkins.jobdsl.model.JenkinsFolder
@@ -179,7 +179,7 @@ Map getMultijobPRConfig(JenkinsFolder jobFolder) {
                 ]
             ], [
                 id: 'optaplanner-quickstarts',
-                repository: 'optaplanner-quickstarts',
+                repository: 'incubator-kie-optaplanner-quickstarts',
                 env : [
                     BUILD_MVN_OPTS_CURRENT: '-Dfull',
                     OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM: '-Dfull',

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -47,7 +47,7 @@ KogitoJobUtils.createMainQuarkusUpdateToolsJob(this,
 
 void setupProjectDroolsJob(String droolsBranch) {
     def jobParams = JobParamsUtils.getBasicJobParamsWithEnv(this, 'optaplanner-drools-snapshot', JobType.NIGHTLY, 'ecosystem', "${jenkins_path_project}/Jenkinsfile.drools", 'Optaplanner testing against Drools snapshot')
-    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.triggers = [ cron : 'H 2 * * *' ]
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
@@ -130,7 +130,7 @@ void setupProjectReleaseJob() {
 
 void setupProjectPostReleaseJob() {
     def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner-post-release', JobType.RELEASE, "${jenkins_path_project}/Jenkinsfile.post-release", 'Optaplanner Post Release')
-    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
@@ -234,7 +234,7 @@ void setupSpecificBuildChainNightlyJob(String envName) {
 
 void createSetupBranchJob() {
     def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner', JobType.SETUP_BRANCH, "${jenkins_path}/Jenkinsfile.setup-branch", 'OptaPlanner Setup Branch')
-    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
         REPO_NAME: 'optaplanner',
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
@@ -262,7 +262,7 @@ void createSetupBranchJob() {
 
 void setupDeployJob(JobType jobType, String envName = '') {
     def jobParams = JobParamsUtils.getBasicJobParamsWithEnv(this, 'optaplanner-deploy', jobType, envName, "${jenkins_path}/Jenkinsfile.deploy", 'Optaplanner Deploy')
-    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     if (jobType == JobType.PULL_REQUEST) {
         jobParams.git.branch = '${BUILD_BRANCH_NAME}'
         jobParams.git.author = '${GIT_AUTHOR}'
@@ -340,7 +340,7 @@ void setupDeployJob(JobType jobType, String envName = '') {
 
 void setupPromoteJob(JobType jobType) {
     def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner-promote', jobType, "${jenkins_path}/Jenkinsfile.promote", 'Optaplanner Promote')
-    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
@@ -383,7 +383,7 @@ void setupPromoteJob(JobType jobType) {
 void setupOptaPlannerTurtleTestsJob(String constraintStreamImplType) {
     def jobParams = JobParamsUtils.getBasicJobParams(this, "optaplanner-turtle-tests-${constraintStreamImplType}", JobType.OTHER, "${jenkins_path}/Jenkinsfile.turtle",
             "Run OptaPlanner turtle tests with CS-${constraintStreamImplType} on a weekly basis.")
-    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
             CONSTRAINT_STREAM_IMPL_TYPE: "${constraintStreamImplType}",
             JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}"

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -23,12 +23,12 @@ fi
 git_author="$(echo ${git_url} | awk -F"${git_server_url}" '{print $2}' | awk -F. '{print $1}'  | awk -F/ '{print $1}')"
 
 export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/optaplanner
-export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=kiegroup/optaplanner
+export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/optaplanner
 export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
 export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/optaplanner
 
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
-curl -o ${file} https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -22,13 +22,13 @@ fi
 
 git_author="$(echo ${git_url} | awk -F"${git_server_url}" '{print $2}' | awk -F. '{print $1}'  | awk -F/ '{print $1}')"
 
-export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/optaplanner
-export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/optaplanner
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/incubator-kie-optaplanner
+export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/incubator-kie-optaplanner
 export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
-export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/optaplanner
+export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/incubator-kie-optaplanner
 
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
-curl -o ${file} https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/apache/incubator-kie-kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@

--- a/.ci/jenkins/project/Jenkinsfile.drools
+++ b/.ci/jenkins/project/Jenkinsfile.drools
@@ -140,7 +140,7 @@ void checkoutOptaplannerQuickstartsRepo() {
 
 void checkoutDroolsRepo() {
     dir(droolsRepo) {
-        checkout(githubscm.resolveRepository(droolsRepo, 'kiegroup', getDroolsBranch(), false))
+        checkout(githubscm.resolveRepository(droolsRepo, 'apache', getDroolsBranch(), false))
     }
 }
 

--- a/.ci/jenkins/project/Jenkinsfile.drools
+++ b/.ci/jenkins/project/Jenkinsfile.drools
@@ -8,18 +8,13 @@ quickstartsRepo = 'optaplanner-quickstarts'
 
 pipeline {
     agent {
-        label 'ubuntu'
+        docker { 
+            image env.AGENT_DOCKER_BUILDER_IMAGE
+            args env.AGENT_DOCKER_BUILDER_ARGS
+        }
     }
     environment {
-        // DROOLS_BRANCH should be defined directly into the job environment
-
         OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
-
-        MAVEN_OPTS = '-Xms1024m -Xmx4g'
-    }
-    tools {
-        maven env.BUILD_MAVEN_TOOL
-        jdk env.BUILD_JDK_TOOL
     }
     options {
         timestamps()

--- a/.ci/jenkins/project/Jenkinsfile.drools
+++ b/.ci/jenkins/project/Jenkinsfile.drools
@@ -2,9 +2,9 @@
 
 import org.kie.jenkins.MavenCommand
 
-droolsRepo = 'drools'
-optaplannerRepo = 'optaplanner'
-quickstartsRepo = 'optaplanner-quickstarts'
+droolsRepo = 'incubator-kie-drools'
+optaplannerRepo = 'incubator-kie-optaplanner'
+quickstartsRepo = 'incubator-kie-optaplanner-quickstarts'
 
 pipeline {
     agent {

--- a/.ci/jenkins/project/Jenkinsfile.nightly
+++ b/.ci/jenkins/project/Jenkinsfile.nightly
@@ -1,7 +1,7 @@
 import org.jenkinsci.plugins.workflow.libs.Library
 @Library('jenkins-pipeline-shared-libraries')_
 
-String optaPlannerRepository = 'optaplanner'
+String optaPlannerRepository = 'incubator-kie-optaplanner'
 String optaPlannerMainBranch = 'main'
 String optaPlanner9xBranch = '9.x'
 

--- a/.ci/jenkins/project/Jenkinsfile.nightly
+++ b/.ci/jenkins/project/Jenkinsfile.nightly
@@ -26,13 +26,7 @@ pipeline {
         timeout(time: 1380, unit: 'MINUTES')
     }
 
-    // parameters {
-    // For parameters, check into ./dsl/jobs.groovy file
-    // }
-
     environment {
-        // Some generated env is also defined into ./dsl/jobs.groovy file
-
         OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
         // Use branch name in nightly tag as we may have parallel main and release branch builds

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -82,40 +82,41 @@ pipeline {
             }
         }
 
-        stage('Update OptaPlanner website') {
-            steps {
-                script {
-                    final String websiteRepository = 'optaplanner-website'
-                    String prLink = null
-                    String prBranchName = "${getProjectVersion().toLowerCase()}-${env.PR_BRANCH_HASH}"
-                    dir("$websiteRepository-pr") {
-                        checkoutRepo(websiteRepository, 'main') // there is no other branch
-                        githubscm.createBranch(prBranchName)
+        // Optaplanner website is not migrated to Apache
+        // stage('Update OptaPlanner website') {
+        //     steps {
+        //         script {
+        //             final String websiteRepository = 'optaplanner-website'
+        //             String prLink = null
+        //             String prBranchName = "${getProjectVersion().toLowerCase()}-${env.PR_BRANCH_HASH}"
+        //             dir("$websiteRepository-pr") {
+        //                 checkoutRepo(websiteRepository, 'main') // there is no other branch
+        //                 githubscm.createBranch(prBranchName)
 
-                        // Update versions in links on the website and in the docs.
-                        sh "./build/update-versions.sh ${getProjectVersion()} ${getNextMinorSnapshotVersion(getProjectVersion())}"
+        //                 // Update versions in links on the website and in the docs.
+        //                 sh "./build/update-versions.sh ${getProjectVersion()} ${getNextMinorSnapshotVersion(getProjectVersion())}"
 
-                        // Update the XSDs. OptaPlanner must be cloned and build with the full profile before.
-                        String optaplannerRoot = "${WORKSPACE}/${optaplannerRepository}"
-                        String optaplannerWebsiteModule = 'optaplanner-website-root'
-                        String optaplannerWebsiteXsd = "${optaplannerWebsiteModule}/content/xsd"
-                        String optaplannerWebsiteDocs = 'optaplanner-website-docs'
-                        sh "cp ${optaplannerRoot}/core/optaplanner-core-impl/target/classes/solver.xsd ${optaplannerWebsiteXsd}/solver/solver-${env.OPTAPLANNER_LATEST_STREAM}.xsd"
-                        sh "cp ${optaplannerRoot}/optaplanner-benchmark/target/classes/benchmark.xsd ${optaplannerWebsiteXsd}/benchmark/benchmark-${env.OPTAPLANNER_LATEST_STREAM}.xsd"
+        //                 // Update the XSDs. OptaPlanner must be cloned and build with the full profile before.
+        //                 String optaplannerRoot = "${WORKSPACE}/${optaplannerRepository}"
+        //                 String optaplannerWebsiteModule = 'optaplanner-website-root'
+        //                 String optaplannerWebsiteXsd = "${optaplannerWebsiteModule}/content/xsd"
+        //                 String optaplannerWebsiteDocs = 'optaplanner-website-docs'
+        //                 sh "cp ${optaplannerRoot}/core/optaplanner-core-impl/target/classes/solver.xsd ${optaplannerWebsiteXsd}/solver/solver-${env.OPTAPLANNER_LATEST_STREAM}.xsd"
+        //                 sh "cp ${optaplannerRoot}/optaplanner-benchmark/target/classes/benchmark.xsd ${optaplannerWebsiteXsd}/benchmark/benchmark-${env.OPTAPLANNER_LATEST_STREAM}.xsd"
 
-                        // Add changed files, commit, open and merge PR
-                        prLink = commitAndCreatePR("Release OptaPlanner ${getProjectVersion()}",
-                                { sh "git add $optaplannerWebsiteXsd/\\*.xsd $optaplannerWebsiteModule/data/pom.yml $optaplannerWebsiteDocs/antora-playbook.yml" },
-                                prBranchName, 'main')
-                    }
-                    dir(websiteRepository) {
-                        checkoutRepo(websiteRepository, 'main')
-                        mergeAndPush(prLink, 'main')
-                        githubscm.removeRemoteBranch('origin', prBranchName, getGitAuthorCredsID())
-                    }
-                }
-            }
-        }
+        //                 // Add changed files, commit, open and merge PR
+        //                 prLink = commitAndCreatePR("Release OptaPlanner ${getProjectVersion()}",
+        //                         { sh "git add $optaplannerWebsiteXsd/\\*.xsd $optaplannerWebsiteModule/data/pom.yml $optaplannerWebsiteDocs/antora-playbook.yml" },
+        //                         prBranchName, 'main')
+        //             }
+        //             dir(websiteRepository) {
+        //                 checkoutRepo(websiteRepository, 'main')
+        //                 mergeAndPush(prLink, 'main')
+        //                 githubscm.removeRemoteBranch('origin', prBranchName, getGitAuthorCredsID())
+        //             }
+        //         }
+        //     }
+        // }
     }
     post {
         unsuccessful {

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -10,12 +10,10 @@ String stableBranchName = 'stable'
 
 pipeline {
     agent {
-        label 'ubuntu'
-    }
-
-    tools {
-        maven env.BUILD_MAVEN_TOOL
-        jdk env.BUILD_JDK_TOOL
+        docker { 
+            image env.AGENT_DOCKER_BUILDER_IMAGE
+            args env.AGENT_DOCKER_BUILDER_ARGS
+        }
     }
 
     options {
@@ -24,13 +22,7 @@ pipeline {
         disableConcurrentBuilds(abortPrevious: true)
     }
 
-    // parameters {
-    // For parameters, check into .jenkins/dsl/jobs.groovy file
-    // }
-
     environment {
-        // Some generated env is also defined into .jenkins/dsl/jobs.groovy file
-
         OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
         PR_BRANCH_HASH = "${util.generateHash(10)}"
@@ -48,10 +40,7 @@ pipeline {
 
                     // Verify version is set and if on right release branch
                     assert getProjectVersion()
-
                     assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
-
-                    installGithubCLI()
                 }
             }
         }
@@ -230,15 +219,6 @@ void commitAndForcePushBranch(String repo, String branch) {
         println "[ERROR] Force push branch: ${branch} from repo : ${repo} failed with exception: ${exception}"
         currentBuild.result = 'UNSTABLE'
     }
-}
-
-void installGithubCLI() {
-    sh """
-    wget https://github.com/cli/cli/releases/download/v${env.GITHUB_CLI_VERSION}/gh_${env.GITHUB_CLI_VERSION}_linux_amd64.tar.gz
-    tar xzf gh_${env.GITHUB_CLI_VERSION}_linux_amd64.tar.gz
-    mv gh_${env.GITHUB_CLI_VERSION}_linux_amd64/bin/gh .
-    rm -r gh_${env.GITHUB_CLI_VERSION}_linux_amd64*
-    """
 }
 
 void uploadDistribution(String directory) {

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -139,7 +139,7 @@ void sendErrorNotification() {
 //////////////////////////////////////////////////////////////////////////////
 
 boolean isNotTestingBuild() {
-    return getGitAuthor() == 'kiegroup'
+    return getGitAuthor() == 'apache'
 }
 
 String getProjectVersion() {

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -4,8 +4,8 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 import org.kie.jenkins.MavenCommand
 
-String optaplannerRepository = 'optaplanner'
-String quickstartsRepository = 'optaplanner-quickstarts'
+String optaplannerRepository = 'incubator-kie-optaplanner'
+String quickstartsRepository = 'incubator-kie-optaplanner-quickstarts'
 String stableBranchName = 'stable'
 
 pipeline {

--- a/.ci/jenkins/project/Jenkinsfile.release
+++ b/.ci/jenkins/project/Jenkinsfile.release
@@ -42,8 +42,8 @@ pipeline {
                     sendNotification("Release Pipeline has started...\nOptaplanner version = ${getOptaPlannerVersion()}\n=> ${env.BUILD_URL}")
 
                     // Safety measure to not publish to main JBoss
-                    if (getGitAuthor() != 'kiegroup' && !getArtifactsRepositoryParam()) {
-                        sendNotification("Git Author is different from `kiegroup` and no `ARTIFACTS_REPOSITORY` parameter has been provided. Are you sure you want to continue ? => ${env.BUILD_URL}input")
+                    if (getGitAuthor() != 'apache' && !getArtifactsRepositoryParam()) {
+                        sendNotification("Git Author is different from `apache` and no `ARTIFACTS_REPOSITORY` parameter has been provided. Are you sure you want to continue ? => ${env.BUILD_URL}input")
                         input message: 'Should the pipeline continue with no `ARTIFACTS_REPOSITORY` defined ?', ok: 'Yes'
                     }
                 }

--- a/.ci/jenkins/project/Jenkinsfile.release
+++ b/.ci/jenkins/project/Jenkinsfile.release
@@ -21,13 +21,7 @@ pipeline {
         label 'ubuntu'
     }
 
-    // parameters {
-    // For parameters, check into ./dsl/jobs.groovy file
-    // }
-
     environment {
-        // Some generated env is also defined into ./dsl/jobs.groovy file
-
         CI_EMAIL = credentials("${JENKINS_EMAIL_CREDS_ID}")
     }
 

--- a/.ci/jenkins/project/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/project/Jenkinsfile.setup-branch
@@ -10,7 +10,6 @@ JOBS = [:]
 FAILED_STAGES = [:]
 UNSTABLE_STAGES = [:]
 
-// Should be multibranch pipeline
 pipeline {
     agent {
         label 'ubuntu'
@@ -20,13 +19,7 @@ pipeline {
         timeout(time: 360, unit: 'MINUTES')
     }
 
-    // parameters {
-    // For parameters, check into ./dsl/jobs.groovy file
-    // }
-
     environment {
-        // Some generated env is also defined into ./dsl/jobs.groovy file
-
         OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
         // Use branch name in nightly tag as we may have parallel main and release branch builds

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,8 @@ a section if that type of information is not available.
 changes that span multiple apache repositories and depend on each other. -->
 <!-- Example:
 - https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
-- https://github.com/apache/drools/pull/3000
-- https://github.com/apache/optaplanner/pull/899
+- https://github.com/apache/incubator-kie-drools/pull/3000
+- https://github.com/apache/incubator-kie-optaplanner/pull/899
 - etc.
 -->
 
@@ -106,7 +106,7 @@ How to retest this PR or trigger a specific build:
 
 ### CI Status
 
- You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
+ You can check OptaPlanner repositories CI status from [Chain Status webpage](https://apache.github.io/incubator-kie-optaplanner/).
 
 <details>
 <summary>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,11 +13,11 @@ a section if that type of information is not available.
 ### Referenced pull requests
 
 <!-- Add URLs of all referenced pull requests if they exist. This is only required when making
-changes that span multiple kiegroup repositories and depend on each other. -->
+changes that span multiple apache repositories and depend on each other. -->
 <!-- Example:
 - https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
-- https://github.com/kiegroup/drools/pull/3000
-- https://github.com/kiegroup/optaplanner/pull/899
+- https://github.com/apache/drools/pull/3000
+- https://github.com/apache/optaplanner/pull/899
 - etc.
 -->
 

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build Chain
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           flow-type: full-downstream

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build Chain
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           flow-type: full-downstream

--- a/.github/workflows/generate_status_page.yaml
+++ b/.github/workflows/generate_status_page.yaml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   generate-status-page:
-    if: github.repository == 'kiegroup/optaplanner'
+    if: github.repository == 'apache/optaplanner'
     concurrency:
       group: generate-status-page
       cancel-in-progress: true
@@ -18,6 +18,6 @@ jobs:
       - name: Generate status page
         uses: kiegroup/chain-status/.ci/actions/generate-app@main
         with:
-          info-md-url: "https://raw.githubusercontent.com/kiegroup/optaplanner/main/.ci/chain-status-info.md"
+          info-md-url: "https://raw.githubusercontent.com/apache/optaplanner/main/.ci/chain-status-info.md"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/generate_status_page.yaml
+++ b/.github/workflows/generate_status_page.yaml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   generate-status-page:
-    if: github.repository == 'apache/optaplanner'
+    if: github.repository == 'apache/incubator-kie-optaplanner'
     concurrency:
       group: generate-status-page
       cancel-in-progress: true
@@ -18,6 +18,6 @@ jobs:
       - name: Generate status page
         uses: kiegroup/chain-status/.ci/actions/generate-app@main
         with:
-          info-md-url: "https://raw.githubusercontent.com/apache/optaplanner/main/.ci/chain-status-info.md"
+          info-md-url: "https://raw.githubusercontent.com/apache/incubator-kie-optaplanner/main/.ci/chain-status-info.md"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/generate_status_page_data.yaml
+++ b/.github/workflows/generate_status_page_data.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 * * * *'
 jobs:
   generate-status-page-data:
-    if: github.repository == 'apache/optaplanner'
+    if: github.repository == 'apache/incubator-kie-optaplanner'
     concurrency:
       group: generate-status-page-data
       cancel-in-progress: true
@@ -20,11 +20,11 @@ jobs:
       - name: Generate status page data
         uses: kiegroup/chain-status/.ci/actions/generate-data@main
         with:
-          definition-file: https://raw.githubusercontent.com/apache/optaplanner/main/.ci/builchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/apache/incubator-kie-optaplanner/main/.ci/builchain-config.yaml
           title: Pull Request Status
           subtitle: OptaPlanner organization repositories CI Status
           base-branch-filter: main,8\.*
-          project-filter: apache/opta.*$
+          project-filter: apache/incubator-kie-opta.*$
           created-by: GitHub Action
           created-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/generate_status_page_data.yaml
+++ b/.github/workflows/generate_status_page_data.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 * * * *'
 jobs:
   generate-status-page-data:
-    if: github.repository == 'kiegroup/optaplanner'
+    if: github.repository == 'apache/optaplanner'
     concurrency:
       group: generate-status-page-data
       cancel-in-progress: true
@@ -20,11 +20,11 @@ jobs:
       - name: Generate status page data
         uses: kiegroup/chain-status/.ci/actions/generate-data@main
         with:
-          definition-file: https://raw.githubusercontent.com/kiegroup/optaplanner/main/.ci/builchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/apache/optaplanner/main/.ci/builchain-config.yaml
           title: Pull Request Status
           subtitle: OptaPlanner organization repositories CI Status
           base-branch-filter: main,8\.*
-          project-filter: kiegroup/opta.*$
+          project-filter: apache/opta.*$
           created-by: GitHub Action
           created-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -20,6 +20,6 @@ jobs:
       uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
       with:
         project: optaplanner
-        main-config-file-repo: apache/optaplanner
+        main-config-file-repo: apache/incubator-kie-optaplanner
         main-config-file-path: .ci/jenkins/config/main.yaml
-        branch-config-file-repo: apache/optaplanner
+        branch-config-file-repo: apache/incubator-kie-optaplanner

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -20,6 +20,6 @@ jobs:
       uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
       with:
         project: optaplanner
-        main-config-file-repo: kiegroup/optaplanner
+        main-config-file-repo: apache/optaplanner
         main-config-file-path: .ci/jenkins/config/main.yaml
-        branch-config-file-repo: kiegroup/optaplanner
+        branch-config-file-repo: apache/optaplanner

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,9 +59,9 @@ jobs:
           # maven-assembly-plugin occasionally fails on heap space when building the ZIP in optaplanner-docs
           MAVEN_OPTS: "-Xmx2048m"
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
-          starting-project: kiegroup/optaplanner
+          starting-project: apache/optaplanner
           flow-type: ${{ env.FLOW_TYPE }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Surefire Report

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,9 +59,9 @@ jobs:
           # maven-assembly-plugin occasionally fails on heap space when building the ZIP in optaplanner-docs
           MAVEN_OPTS: "-Xmx2048m"
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
-          starting-project: apache/optaplanner
+          starting-project: apache/incubator-kie-optaplanner
           flow-type: ${{ env.FLOW_TYPE }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Surefire Report


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
