### PR TITLE
PR multibranchPipelineJob

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
     options {
         timestamps()
-        timeout(time: '720', unit: 'MINUTES')
+        timeout(time: 720, unit: 'MINUTES')
     }
     environment {
         BUILDCHAIN_PROJECT = 'kiegroup/optaplanner'

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -192,9 +192,7 @@ Map getMultijobPRConfig(JenkinsFolder jobFolder) {
 }
 
 // Optaplanner PR checks
-// Deactivated due to ghprb not available on Apache Jenkins
-// TODO create PR job with branch source plugin
-// KogitoJobUtils.createAllEnvironmentsPerRepoPRJobs(this) { jobFolder -> getMultijobPRConfig(jobFolder) }
+Utils.isMainBranch(this) && KogitoJobTemplate.createPullRequestMultibranchPipelineJob(this, "${jenkins_path}/Jenkinsfile")
 
 // Setup branch branch
 createSetupBranchJob()


### PR DESCRIPTION
Enabling a simplified PR check, which repeatedly (each 5 minutes) polls for new PRs coming from both the origin itself and forks.

Full ensemble:
https://github.com/kiegroup/kogito-runtimes/pull/3224
https://github.com/kiegroup/kogito-apps/pull/1879
https://github.com/kiegroup/kogito-examples/pull/1808
https://github.com/kiegroup/drools/pull/5523
https://github.com/kiegroup/kogito-images/pull/1700
https://github.com/kiegroup/optaplanner-quickstarts/pull/602
https://github.com/apache/incubator-kie-optaplanner/pull/2975
