### PR TITLE
Remove branch override for quickstarts from branch config

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -28,7 +28,6 @@ repositories:
   job_display_name: optaplanner
 - name: incubator-kie-optaplanner-quickstarts
   job_display_name: optaplanner-quickstarts
-  branch: 8.x
 # Not migrated to Apache yet
 # - name: incubator-kie-optaplanner-website
 #   job_display_name: optaplanner-website


### PR DESCRIPTION
Removing older branch override, because changes are currently  in apache_migration branches only.