### PR TITLE
kie-issues#593: switch to compile downstream in Jenkins

### DIFF
--- a/.ci/buildchain-config-pr-cdb.yaml
+++ b/.ci/buildchain-config-pr-cdb.yaml
@@ -1,0 +1,47 @@
+version: "2.1"
+
+dependencies: ./buildchain-project-dependencies.yaml
+
+pre: |
+  export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -nsu -ntp -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
+  echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
+  export BUILD_MVN_OPTS_CURRENT="${{ env.BUILD_MVN_OPTS_CURRENT }} dependency:tree"
+  echo "BUILD_MVN_OPTS_CURRENT=${{ env.BUILD_MVN_OPTS_CURRENT }}"
+  echo "QUARKUS_VERSION=${{ env.QUARKUS_VERSION }}"
+
+default:
+  build-command:
+    before:
+      current: |
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh "${{ env.BUILD_ENVIRONMENT }}"; fi"
+      upstream: |
+        bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh "${{ env.BUILD_ENVIRONMENT }}"; fi"
+    current: |
+      mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
+    upstream: |
+      mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
+    after:
+      current: |
+        docker system prune -f
+
+build:
+  - project: apache/incubator-kie-optaplanner
+    build-command:
+      before:
+        upstream: |
+          bash -c "if [ \"${{ env.MIGRATE_TO_9 }}\" == \"true\" ]; then ./build/8-to-9-migration/migrate.sh --no-commit; fi"
+      current: |
+        mvn clean install -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS }}
+      upstream: |
+        mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM }}
+      downstream: |
+        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_DOWNSTREAM }}
+
+  - project: apache/incubator-kie-optaplanner-quickstarts
+    build-command:
+      current: |
+        mvn clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.OPTAPLANNER_QUICKSTARTS_BUILD_MVN_OPTS }}
+      upstream: |
+        mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAPLANNER_QUICKSTARTS_BUILD_MVN_OPTS_UPSTREAM }}
+      downstream: |
+        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.OPTAPLANNER_QUICKSTARTS_BUILD_MVN_OPTS_DOWNSTREAM }}

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     environment {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-optaplanner'
         BUILDCHAIN_CONFIG_REPO = 'incubator-kie-optaplanner'
-        BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config.yaml'
+        BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config-pr-cdb.yaml'
 
         ENABLE_SONARCLOUD = 'true'
         SONARCLOUD_ANALYSIS_MVN_OPTS = '-Dsonar.projectKey=org.optaplanner:optaplanner'


### PR DESCRIPTION
apache/incubator-kie-issues#593

Adding an extra Compile Downstream build-chain configuration for PRs, which is a copy of existing + definition of downstream scripts.

Reason is not to break existing configuration of other pipelines that use the original build-chain configuration - needs to be reviewed when I have better grasp of all affected places, scoping to jenkins PR check for now.