### PR TITLE
kie-issues#593: use install goal for downstream projects

### DIFF
--- a/.ci/buildchain-config-pr-cdb.yaml
+++ b/.ci/buildchain-config-pr-cdb.yaml
@@ -35,7 +35,7 @@ build:
       upstream: |
         mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM }}
       downstream: |
-        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_DOWNSTREAM }}
+        mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.OPTAPLANNER_BUILD_MVN_OPTS_DOWNSTREAM }}
 
   - project: apache/incubator-kie-optaplanner-quickstarts
     build-command:
@@ -44,4 +44,4 @@ build:
       upstream: |
         mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.OPTAPLANNER_QUICKSTARTS_BUILD_MVN_OPTS_UPSTREAM }}
       downstream: |
-        mvn clean compile ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.OPTAPLANNER_QUICKSTARTS_BUILD_MVN_OPTS_DOWNSTREAM }}
+        mvn clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.OPTAPLANNER_QUICKSTARTS_BUILD_MVN_OPTS_DOWNSTREAM }}


### PR DESCRIPTION
apache/incubator-kie-issues#593
For the chain to successfully complete, the maven builds should invoke install goal instead of compile.
This is needed due to dependent projects down the chain that would miss the artifacts if they were not installed.