### PR TITLE
kie-issues#599: disable sonar in PR checks

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         BUILDCHAIN_CONFIG_REPO = 'incubator-kie-optaplanner'
         BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config-pr-cdb.yaml'
 
-        ENABLE_SONARCLOUD = 'true'
+        ENABLE_SONARCLOUD = 'false'
         SONARCLOUD_ANALYSIS_MVN_OPTS = '-Dsonar.projectKey=org.optaplanner:optaplanner'
         OPTAPLANNER_BUILD_MVN_OPTS = '-Prun-code-coverage'
     }


### PR DESCRIPTION
First task in regards to apache/incubator-kie-issues#599

Disabling sonar checks, as it currently breaks the build due to bug and misconfiguration.