### PR TITLE
kie-issues#641: enable triggers for jenkins pipelines

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -22,7 +22,7 @@ environments:
     ids:
     - ecosystem
 disable:
-  triggers: true # TODO to set back
+  deploy: true
 repositories:
 - name: incubator-kie-optaplanner
   job_display_name: optaplanner


### PR DESCRIPTION
apache/incubator-kie-issues#641

Enabling triggers for jenkins pipelines.

Together with that disabling deploy, so that nightly builds (now being triggered) don't fail due to non-configured nexus deployment.