### PR TITLE
kie-issues#654: simplify buildchain configuration

### DIFF
--- a/.ci/buildchain-project-dependencies.yaml
+++ b/.ci/buildchain-project-dependencies.yaml
@@ -8,12 +8,12 @@ dependencies:
       dependencies:
         default:
           - source: development
-            target: main # should migrate to 9 before the build
-          - source: 8.x # does not migrate
+            target: 9.x
+          - source: 8.x
             target: main
       dependant:
         default:
           - source: 9.x
             target: development
-          - source: main # should migrate to 9 before the build
-            target: development
+          - source: main
+            target: 8.x


### PR DESCRIPTION
apache/incubator-kie-issues#654

Simplifying build-chain project configuration, so that there's a direct mapping between matching branches in optaplanner and optaplanner-quickstarts.
Does remove the need for MIGRATE_TO_9 env variable and handling.

Should be considered as unblocking the non-working PR checks at the moment, with assumption this logic would be brought back when needed.