### PR TITLE
kie-issues#667: fix cleanup and settingsXml handling

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -8,7 +8,9 @@ import org.kie.jenkins.MavenStagingHelper
 deployProperties = [:]
 
 optaplannerRepository = 'incubator-kie-optaplanner'
+optaplannerFolder = 'optaplanner'
 quickstartsRepository = 'incubator-kie-optaplanner-quickstarts'
+quickstartsFolder = 'quickstarts'
 
 imageUtils = null
 
@@ -39,7 +41,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -75,8 +77,8 @@ pipeline {
         stage('Clone repositories') {
             steps {
                 script {
-                    checkoutRepo(optaplannerRepository)
-                    checkoutQuickstarts()
+                    checkoutRepo(optaplannerRepository, optaplannerFolder)
+                    checkoutQuickstarts(quickstartsFolder)
                 }
             }
         }
@@ -87,8 +89,8 @@ pipeline {
             }
             steps {
                 script {
-                    prepareForPR(optaplannerRepository)
-                    prepareForPR(quickstartsRepository)
+                    prepareForPR(optaplannerFolder)
+                    prepareForPR(quickstartsFolder)
                 }
             }
         }
@@ -112,13 +114,16 @@ pipeline {
         stage('Build OptaPlanner') {
             steps {
                 script {
-                    getOptaplannerMavenCommand()
-                            .withProperty('maven.test.failure.ignore', true)
-                            .withProperty('operator.image.build')
-                            .skipTests(params.SKIP_TESTS)
-                            .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getOptaplannerMavenCommand()
+                                .withProperty('maven.test.failure.ignore', true)
+                                .withProperty('operator.image.build')
+                                .skipTests(params.SKIP_TESTS)
+                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                .run('clean install')
+                    }
                     if (isRelease()) {
-                        updateAntoraYaml(optaplannerRepository)
+                        updateAntoraYaml(optaplannerFolder)
                     }
                 }
             }
@@ -135,10 +140,13 @@ pipeline {
         stage('Build Quickstarts') {
             steps {
                 script {
-                    getOptaplannerQuickstartsMavenCommand()
-                            .withProperty('maven.test.failure.ignore', true)
-                            .skipTests(params.SKIP_TESTS)
-                            .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getOptaplannerQuickstartsMavenCommand()
+                                .withProperty('maven.test.failure.ignore', true)
+                                .skipTests(params.SKIP_TESTS)
+                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                .run('clean install')
+                    }
                 }
             }
             post {
@@ -201,8 +209,8 @@ pipeline {
             }
             steps {
                 script {
-                    commitAndCreatePR(optaplannerRepository, getBuildBranch())
-                    commitAndCreatePR(quickstartsRepository, getQuickStartsBranch())
+                    commitAndCreatePR(optaplannerFolder, optaplannerRepository, getBuildBranch())
+                    commitAndCreatePR(quickstartsFolder, quickstartsRepository, getQuickStartsBranch())
                 }
             }
             post {
@@ -246,8 +254,7 @@ pipeline {
         }
         cleanup {
             script {
-                // Clean also docker in case of usage of testcontainers lib
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -269,10 +276,10 @@ List getIntegrationTestProfiles() {
 void updateQuickstartsVersions() {
     maven.mvnSetVersionProperty(getOptaplannerQuickstartsMavenCommand(), 'version.org.optaplanner', getProjectVersion())
     maven.mvnVersionsUpdateParentAndChildModules(getOptaplannerQuickstartsMavenCommand(), getProjectVersion(), !isRelease())
-    gradleVersionsUpdate(quickstartsRepository, getProjectVersion())
+    gradleVersionsUpdate(quickstartsFolder, getProjectVersion())
 
     if (isRelease()) {
-        dir(quickstartsRepository) {
+        dir(quickstartsFolder) {
             // TODO: Remove the exclusion after the kubernetes demo is migrated to 9.
             assert !sh(script:
                     'grep -Rn "SNAPSHOT" --include={pom.xml,build.gradle} --exclude-dir=kubernetes | ' +
@@ -281,7 +288,7 @@ void updateQuickstartsVersions() {
         }
     }
     if (isCreatePr()) {
-        dir(quickstartsRepository) {
+        dir(quickstartsFolder) {
             // TODO: Remove the exclusion after the kubernetes demo is migrated to 9.
             assert !sh(script:
                     'grep -Rn "SNAPSHOT" --include={pom.xml,build.gradle} --exclude-dir=kubernetes | ' +
@@ -291,8 +298,8 @@ void updateQuickstartsVersions() {
     }
 }
 
-void gradleVersionsUpdate(String repo, String newVersion) {
-    dir(repo) {
+void gradleVersionsUpdate(String folder, String newVersion) {
+    dir(folder) {
         sh "find . -name build.gradle -exec sed -i -E 's/def optaplannerVersion = \"[^\"\\s]+\"/def optaplannerVersion = \"${newVersion}\"/' {} \\;"
     }
 }
@@ -330,14 +337,14 @@ String getFallbackBranch(String repo) {
     return repositoryScm ? params.PR_TARGET_BRANCH : 'main'
 }
 
-void prepareForPR(String repo) {
-    dir(repo) {
+void prepareForPR(String folder) {
+    dir(folder) {
         githubscm.createBranch(getPRBranch())
     }
 }
 
-void commitAndCreatePR(String repo, String buildBranch) {
-    dir(repo) {
+void commitAndCreatePR(String folder, String repo, String buildBranch) {
+    dir(folder) {
         def commitMsg = "[${buildBranch}] Update project version to ${getProjectVersion()}"
         def prBody = "Generated by build ${BUILD_TAG}: ${BUILD_URL}."
         if (isRelease()) {
@@ -358,16 +365,16 @@ void commitAndCreatePR(String repo, String buildBranch) {
     }
 }
 
-void commitAndCreatePRIgnoringNpmRegistry(String repo, String buildBranch) {
-    dir(repo) {
+void commitAndCreatePRIgnoringNpmRegistry(String folder, String repo, String buildBranch) {
+    dir(folder) {
         sh 'sed \'s;repository.engineering.redhat.com/nexus/repository/;;\' -i */package-lock.json'
         sh 'git add */package-lock.json'
     }
-    commitAndCreatePR(repo, buildBranch)
+    commitAndCreatePR(folder, repo, buildBranch)
 }
 
 MavenCommand getMavenDefaultCommand() {
-    MavenCommand mvnCmd = new MavenCommand(this, ['-fae', '-ntp']).withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
+    MavenCommand mvnCmd = new MavenCommand(this, ['-fae', '-ntp'])
     if (env.MAVEN_DEPENDENCIES_REPOSITORY) {
         mvnCmd.withDependencyRepositoryInSettings('deps-repo', env.MAVEN_DEPENDENCIES_REPOSITORY)
     }
@@ -375,21 +382,24 @@ MavenCommand getMavenDefaultCommand() {
 }
 
 MavenCommand getOptaplannerMavenCommand() {
-    return getMavenDefaultCommand().inDirectory(optaplannerRepository).withProperty('full')
+    return getMavenDefaultCommand().inDirectory(optaplannerFolder).withProperty('full')
 }
 
 MavenCommand getOptaplannerQuickstartsMavenCommand() {
-    return getMavenDefaultCommand().inDirectory(quickstartsRepository).withProperty('full')
+    return getMavenDefaultCommand().inDirectory(quickstartsFolder).withProperty('full')
 }
 
 /**
  * Builds the parent modules and the BOM so that project depending on these artifacts can resolve.
  */
 void mavenCleanInstallOptaPlannerParents() {
-    getOptaplannerMavenCommand()
-            .skipTests(true)
-            .withOptions(['-U', '-pl org.optaplanner:optaplanner-build-parent,org.optaplanner:optaplanner-bom', '-am'])
-            .run('clean install')
+    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+        getOptaplannerMavenCommand()
+                .skipTests(true)
+                .withOptions(['-U', '-pl org.optaplanner:optaplanner-build-parent,org.optaplanner:optaplanner-bom', '-am'])
+                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                .run('clean install')
+    }
 }
 
 void runMavenDeploy(MavenCommand mvnCmd, String localDeploymentId = '') {
@@ -401,7 +411,12 @@ void runMavenDeploy(MavenCommand mvnCmd, String localDeploymentId = '') {
         mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
 
-    mvnCmd.skipTests(true).run('clean deploy')
+    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+        mvnCmd
+          .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+          .skipTests(true)
+          .run('clean deploy')
+    }
 }
 
 String getMavenRepoZipUrl() {
@@ -427,15 +442,15 @@ String getLocalDeploymentFolder(String localDeployId) {
 // Getters and Setters of params/properties
 
 boolean isSpecificArtifactsUpload() {
-    return env.MAVEN_DEPLOY_REPOSITORY && env.MAVEN_REPO_CREDS_ID
+    return env.MAVEN_DEPLOY_REPOSITORY && env.MAVEN_REPO_CREDS_ID && !isDeployDisabled()
 }
 
 boolean shouldStageArtifacts() {
-    return !isSpecificArtifactsUpload() && isRelease() && !env.MAVEN_DEPLOY_REPOSITORY
+    return !isSpecificArtifactsUpload() && isRelease() && !env.MAVEN_DEPLOY_REPOSITORY && !isDeployDisabled()
 }
 
 boolean shouldDeployToRepository() {
-    return env.MAVEN_DEPLOY_REPOSITORY || isNotTestingBuild()
+    return (env.MAVEN_DEPLOY_REPOSITORY || isNotTestingBuild()) && !isDeployDisabled()
 }
 
 boolean isNotTestingBuild() {
@@ -541,4 +556,8 @@ boolean isStream8() {
 
 boolean isStream9() {
     return env.OPTAPLANNER_LATEST_STREAM == '9'
+}
+
+boolean isDeployDisabled() {
+    return env.DISABLE_DEPLOY.toBoolean()
 }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -35,7 +35,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -92,11 +92,14 @@ pipeline {
         stage('Upload OptaPlanner documentation') {
             steps {
                 script {
-                    getMavenCommand()
-                            .inDirectory(optaplannerRepository)
-                            .skipTests(true)
-                            .withProperty('full')
-                            .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand()
+                                .inDirectory(optaplannerRepository)
+                                .skipTests(true)
+                                .withProperty('full')
+                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                .run('clean install')
+                    }
                     uploadDistribution(optaplannerRepository)
                 }
             }
@@ -118,7 +121,7 @@ pipeline {
         cleanup {
             script {
                 // Clean also docker in case of usage of testcontainers lib
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -246,7 +249,6 @@ void uploadDistribution(String directory) {
 
 MavenCommand getMavenCommand() {
     mvnCmd = new MavenCommand(this, ['-fae', '-ntp'])
-                    .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
     if (env.MAVEN_DEPENDENCIES_REPOSITORY) {
         mvnCmd.withDependencyRepositoryInSettings('deps-repo', env.MAVEN_DEPENDENCIES_REPOSITORY)
     }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -84,7 +84,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -128,7 +128,6 @@ String getGitAuthorCredsId() {
 
 MavenCommand getMavenCommand() {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withProperty('full')
 }
 

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -41,7 +41,13 @@ pipeline {
             steps {
                 script {
                     dir(getRepoName()) {
-                        maven.mvnVersionsSet(getMavenCommand(), getOptaPlannerVersion(), true)
+                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                            maven.mvnVersionsSet(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                getOptaPlannerVersion(),
+                                true
+                            )
+                        }
                     }
                 }
             }

--- a/.ci/jenkins/Jenkinsfile.turtle
+++ b/.ci/jenkins/Jenkinsfile.turtle
@@ -31,16 +31,18 @@ pipeline {
         stage('Build OptaPlanner with turtle tests') {
             steps {
                 script {
-                    new MavenCommand(this)
-                            // Use the same settings.xml as for the nightly builds, including a maven mirror.
-                            .withSettingsXmlId('kie-release-settings')
+                    // Use the same settings.xml as for the nightly builds, including a maven mirror.
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        new MavenCommand(this)
                             .inDirectory(optaplannerRepo)
                             .withOptions(['-U', '-e', '-fae', '-ntp'])
                             .withProperty('full')
                             .withProperty('runTurtleTests', true)
                             .withProperty('maven.test.failure.ignore', true)
                             .withProperty('constraintStreamImplType', getConstraintStreamImplType())
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
                             .run('clean install')
+                    }
                 }
             }
         }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -289,7 +289,8 @@ void setupDeployJob(JobType jobType, String envName = '') {
 
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
-        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream()
+        OPTAPLANNER_LATEST_STREAM: getOptaPlannerLatestStream(),
+        DISABLE_DEPLOY: Utils.isDeployDisabled(this),
     ])
     if (jobType == JobType.PULL_REQUEST) {
         jobParams.env.putAll([

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -72,6 +72,7 @@ void setupProjectDroolsJob(String droolsBranch) {
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
         NOTIFICATION_JOB_NAME: 'Drools snapshot check',
         DROOLS_BRANCH: droolsBranch,
+        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {
@@ -403,7 +404,8 @@ void setupOptaPlannerTurtleTestsJob(String constraintStreamImplType) {
     JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
             CONSTRAINT_STREAM_IMPL_TYPE: "${constraintStreamImplType}",
-            JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}"
+            JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
+            MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
     ])
     jobParams.triggers = [ cron : 'H H * * 5' ] // Run every Friday.
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {

--- a/.ci/jenkins/project/Jenkinsfile.drools
+++ b/.ci/jenkins/project/Jenkinsfile.drools
@@ -34,9 +34,12 @@ pipeline {
         stage('Build drools') {
             steps {
                 script {
-                    getMavenCommand(droolsRepo)
-                        .withProperty('quickly')
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(droolsRepo)
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
             post {
@@ -67,10 +70,13 @@ pipeline {
         stage('Build optaplanner') {
             steps {
                 script {
-                    getMavenCommand(optaplannerRepo)
-                        .withProperty('maven.test.failure.ignore', true)
-                        .withProperty('version.org.drools', env.DROOLS_VERSION)
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(optaplannerRepo)
+                            .withProperty('maven.test.failure.ignore', true)
+                            .withProperty('version.org.drools', env.DROOLS_VERSION)
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
             post {
@@ -87,10 +93,13 @@ pipeline {
         stage('Build optaplanner-quickstarts') {
             steps {
                 script {
-                    getMavenCommand(quickstartsRepo)
-                        .withProperty('maven.test.failure.ignore', true)
-                        .withProperty('version.org.drools', env.DROOLS_VERSION)
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(quickstartsRepo)
+                            .withProperty('maven.test.failure.ignore', true)
+                            .withProperty('version.org.drools', env.DROOLS_VERSION)
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
             post {
@@ -108,7 +117,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -146,7 +155,6 @@ void checkoutDroolsRepo() {
 
 MavenCommand getMavenCommand(String directory) {
     def mvnCmd = new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId('kie-release-settings')
                 .inDirectory(directory)
     if (env.BUILD_MVN_OPTS) {
         mvnCmd.withOptions([ env.BUILD_MVN_OPTS ])

--- a/.ci/jenkins/project/Jenkinsfile.post-release
+++ b/.ci/jenkins/project/Jenkinsfile.post-release
@@ -32,7 +32,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -75,8 +75,20 @@ pipeline {
         stage('Upload OptaPlanner distribution from Quickstarts') {
             steps {
                 script {
-                    getMavenCommand().inDirectory(optaplannerRepository).withProperty('quickly').withProperty('full').run('clean install')
-                    getMavenCommand().inDirectory(quickstartsRepository).skipTests(true).withProperty('full').run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand()
+                            .inDirectory(optaplannerRepository)
+                            .withProperty('quickly')
+                            .withProperty('full')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                        getMavenCommand()
+                            .inDirectory(quickstartsRepository)
+                            .skipTests(true)
+                            .withProperty('full')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                     uploadDistribution(quickstartsRepository)
                 }
             }
@@ -124,8 +136,7 @@ pipeline {
         }
         cleanup {
             script {
-                // Clean also docker in case of usage of testcontainers lib
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -240,7 +251,6 @@ void uploadDistribution(String directory) {
 
 MavenCommand getMavenCommand() {
     mvnCmd = new MavenCommand(this, ['-fae'])
-                    .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
     if (env.MAVEN_DEPENDENCIES_REPOSITORY) {
         mvnCmd.withDependencyRepositoryInSettings('deps-repo', env.MAVEN_DEPENDENCIES_REPOSITORY)
     }

--- a/.ci/jenkins/project/Jenkinsfile.release
+++ b/.ci/jenkins/project/Jenkinsfile.release
@@ -127,6 +127,8 @@ pipeline {
             script {
                 saveReleaseProperties()
             }
+        }
+        cleanup {
             cleanWs()
         }
         success {


### PR DESCRIPTION
After #3009 

apache/incubator-kie-issues#667

Fixing cleanup and settings.xml pipeline configuration to work correctly in ASF Jenkins.

* Deferred wipeout was causing issues when invoked in early stages
* Docker cleanup can't be done since the overall build is in docker container that uses the docker.sock from the host - it would attempt to erase itself.
* withSettingsXmlId shared library method does imply usage of a prohibited groovy method, thus replacing with explicit configFileProvider and passing as withSettingsXmlFile goes around that part of code. 

Complete list:
apache/incubator-kie-kogito-pipelines#1113
apache/incubator-kie-kogito-runtimes#3272
apache/incubator-kie-kogito-apps#1909
apache/incubator-kie-kogito-examples#1820
apache/incubator-kie-drools#5572
apache/incubator-kie-optaplanner#3010
apache/incubator-kie-optaplanner-quickstarts#613
apache/incubator-kie-kogito-docs#514
apache/incubator-kie-docs#4531
apache/incubator-kie-benchmarks#273