### PR TITLE
kie-issues#710: configure dind image

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -75,8 +75,8 @@ jenkins:
   agent:
     docker:
       builder:
-        image: quay.io/kiegroup/kogito-ci-build:19a0b303bc64f473a01f5fa5bacde822f10b4946 # last main-latest based on ubi
-        args: -v /var/run/docker.sock:/var/run/docker.sock --group-add docker --group-add input --group-add render
+        image: quay.io/kiegroup/kogito-ci-build:main-latest
+        args: --privileged --group-add docker
   default_tools:
     jdk: jdk_17_latest
     maven: maven_3.8.6


### PR DESCRIPTION
apache/incubator-kie-issues#710

Switching configuration to use docker in docker image variant now available under main-latest tag.

Follows-up on: apache/incubator-kie-kogito-pipelines#1125

Part of ensemble:
apache/incubator-kie-kogito-pipelines#1127
apache/incubator-kie-drools#5593
apache/incubator-kie-optaplanner#3026
