### PR TITLE
[incubator-kie-issues#655] Build optaplanner quickstarts from correct branch

### DIFF
--- a/.ci/jenkins/project/Jenkinsfile.nightly
+++ b/.ci/jenkins/project/Jenkinsfile.nightly
@@ -67,8 +67,15 @@ pipeline {
                     def buildParams = getDefaultBuildParams(getBuildBranch())
                     addSkipTestsParam(buildParams)
                     addSkipIntegrationTestsParam(buildParams)
-                    def quickstartsBranch = getBuildBranch() == 'main' || getBuildBranch() == '9.x'
-                            ? 'development' : getBuildBranch()
+                    String quickstartsBranch
+                    switch (getBuildBranch()) {
+                        case 'main': quickstartsBranch = '8.x'
+                            break
+                        case '9.x': quickstartsBranch = 'development'
+                            break
+                        default : quickstartsBranch = getBuildBranch()
+                    }
+
                     addStringParam(buildParams, 'QUICKSTARTS_BUILD_BRANCH_NAME', quickstartsBranch)
 
                     buildJob(OPTAPLANNER_DEPLOY, buildParams)


### PR DESCRIPTION
https://github.com/apache/incubator-kie-issues/issues/655

adjust mapping of optaplanner-quickstarts branches to the upstream ones so the correct one is used.

