### PR TITLE
kie-issues#742: upgrade jacoco maven plugin to 0.8.11

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -71,7 +71,7 @@
     <version.dependency.plugin>3.5.0</version.dependency.plugin>
     <version.formatter.plugin>2.23.0</version.formatter.plugin>
     <version.impsort.plugin>1.9.0</version.impsort.plugin>
-    <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
+    <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
     <!--
       Do not upgrade unless prepared to deal with JPMS issues.
       If upgrading, ensure build still passes with the full profile (-Dfull).


### PR DESCRIPTION
Fixes:
* apache/incubator-kie-issues#742

To have all projects in sync, upgrading jacoco maven plugin, even though it does not have problems on JDK17, unlike the rest of our projects.