### PR TITLE
[kie-issues#913] Upgrade to Quarkus 3.2.10.Final LTS version. Upgrade to and align with Quarkus 3.2.10.Final LTS release.

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -46,7 +46,7 @@
     <version.org.apache.logging.log4j>2.20.0</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.20</version.com.thoughtworks.xstream>
     <version.io.quarkiverse.operatorsdk>6.0.3</version.io.quarkiverse.operatorsdk>
-    <version.io.quarkus>3.2.9.Final</version.io.quarkus>
+    <version.io.quarkus>3.2.10.Final</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.10.0</version.org.apache.commons.text>
     <version.org.apache.poi>5.2.3</version.org.apache.poi>


### PR DESCRIPTION
Tracker: https://github.com/apache/incubator-kie-issues/issues/913

Aligns with Quarkus 3.2.10.Final and the dependency upgrades in the new release.