### PR TITLE
Replace QuarkusTest and Hibernate with OpenJPA

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -49,7 +49,6 @@
     <version.io.quarkus>3.2.10.Final</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.10.0</version.org.apache.commons.text>
-    <version.org.apache.derby>10.16.1.1</version.org.apache.derby>
     <version.org.apache.openjpa>4.0.0</version.org.apache.openjpa>
     <version.org.apache.poi>5.2.3</version.org.apache.poi>
     <version.org.assertj>3.24.2</version.org.assertj>
@@ -179,16 +178,6 @@
         <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
         <version>${version.org.jfree.jfreechart}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.derby</groupId>
-        <artifactId>derby</artifactId>
-        <version>${version.org.apache.derby}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.derby</groupId>
-        <artifactId>derbytools</artifactId>
-        <version>${version.org.apache.derby}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.openjpa</groupId>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -49,6 +49,8 @@
     <version.io.quarkus>3.2.10.Final</version.io.quarkus>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.10.0</version.org.apache.commons.text>
+    <version.org.apache.derby>10.16.1.1</version.org.apache.derby>
+    <version.org.apache.openjpa>4.0.0</version.org.apache.openjpa>
     <version.org.apache.poi>5.2.3</version.org.apache.poi>
     <version.org.assertj>3.24.2</version.org.assertj>
     <version.org.freemarker>2.3.32</version.org.freemarker>
@@ -177,6 +179,21 @@
         <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
         <version>${version.org.jfree.jfreechart}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derby</artifactId>
+        <version>${version.org.apache.derby}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derbytools</artifactId>
+        <version>${version.org.apache.derby}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.openjpa</groupId>
+        <artifactId>openjpa</artifactId>
+        <version>${version.org.apache.openjpa}</version>
       </dependency>
       <!-- optaplanner-operator -->
       <dependency>

--- a/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
@@ -80,28 +80,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <groupId>org.apache.openjpa</groupId>
+      <artifactId>openjpa</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-hibernate-orm</artifactId>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-narayana-jta</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.inject</groupId>
-      <artifactId>jakarta.inject-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-jdbc-h2</artifactId>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbytools</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -113,6 +103,17 @@
         <filtering>false</filtering>
       </testResource>
     </testResources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <argLine>-javaagent:${settings.localRepository}/org/apache/openjpa/openjpa/${version.org.apache.openjpa}/openjpa-${version.org.apache.openjpa}.jar</argLine>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
 </project>

--- a/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
@@ -85,13 +85,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derby</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derbytools</artifactId>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/bendable/BendableScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/bendable/BendableScoreConverterTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class BendableScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreConverterTest.java
@@ -28,9 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class BendableBigDecimalScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/bendablelong/BendableLongScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/bendablelong/BendableLongScoreConverterTest.java
@@ -26,28 +26,25 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class BendableLongScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test
     void persistAndMerge() {
-        persistAndMerge(new BendaleLongScoreConverterTestJpaEntity(BendableLongScore.zero(3, 2)), null,
+        persistAndMerge(new BendableLongScoreConverterTestJpaEntity(BendableLongScore.zero(3, 2)), null,
                 BendableLongScore.of(new long[] { 10000L, 2000L, 300L }, new long[] { 40L, 5L }),
                 BendableLongScore.ofUninitialized(-7, new long[] { 10000L, 2000L, 300L }, new long[] { 40L, 5L }));
     }
 
     @Entity
-    static class BendaleLongScoreConverterTestJpaEntity extends AbstractTestJpaEntity<BendableLongScore> {
+    static class BendableLongScoreConverterTestJpaEntity extends AbstractTestJpaEntity<BendableLongScore> {
 
         @Convert(converter = BendableLongScoreConverter.class)
         protected BendableLongScore score;
 
-        BendaleLongScoreConverterTestJpaEntity() {
+        BendableLongScoreConverterTestJpaEntity() {
         }
 
-        public BendaleLongScoreConverterTestJpaEntity(BendableLongScore score) {
+        public BendableLongScoreConverterTestJpaEntity(BendableLongScore score) {
             this.score = score;
         }
 

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardmediumsoft/HardMediumSoftScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardmediumsoft/HardMediumSoftScoreConverterTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class HardMediumSoftScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardmediumsoftbigdecimal/HardMediumSoftBigDecimalScoreConverterTest.java
@@ -28,9 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class HardMediumSoftBigDecimalScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreConverterTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class HardMediumSoftLongScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardsoft/HardSoftScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardsoft/HardSoftScoreConverterTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class HardSoftScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreConverterTest.java
@@ -28,9 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class HardSoftBigDecimalScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardsoftlong/HardSoftLongScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/hardsoftlong/HardSoftLongScoreConverterTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class HardSoftLongScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/simple/SimpleScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/simple/SimpleScoreConverterTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class SimpleScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/simplebigdecimal/SimpleBigDecimalScoreConverterTest.java
@@ -28,9 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class SimpleBigDecimalScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/simplelong/SimpleLongScoreConverterTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/api/score/buildin/simplelong/SimpleLongScoreConverterTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
 import org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest;
 
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
 class SimpleLongScoreConverterTest extends AbstractScoreJpaTest {
 
     @Test

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/AbstractScoreJpaTest.java
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/java/org/optaplanner/persistence/jpa/impl/AbstractScoreJpaTest.java
@@ -21,19 +21,24 @@ package org.optaplanner.persistence.jpa.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Persistence;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.optaplanner.core.api.score.Score;
 
 public abstract class AbstractScoreJpaTest {
 
-    @Inject
+    @BeforeEach
+    void setUp() {
+        entityManagerFactory = Persistence.createEntityManagerFactory("test");
+    }
+
     EntityManagerFactory entityManagerFactory;
 
     protected <Score_ extends Score<Score_>, E extends AbstractTestJpaEntity<Score_>> Long persistAndAssert(E jpaEntity) {

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/resources/META-INF/persistence.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/resources/META-INF/persistence.xml
@@ -35,12 +35,9 @@
     <class>org.optaplanner.persistence.jpa.api.score.buildin.bendablelong.BendableLongScoreConverterTest$BendableLongScoreConverterTestJpaEntity</class>
     <class>org.optaplanner.persistence.jpa.api.score.buildin.simplebigdecimal.SimpleBigDecimalScoreConverterTest$SimpleBigDecimalScoreConverterTestJpaEntity</class>
     <properties>
-      <property name="jakarta.persistence.schema-generation.database.action"
-                value="drop-and-create"/>
-      <property name="jakarta.persistence.jdbc.driver"
-                value="org.apache.derby.jdbc.EmbeddedDriver"/>
-      <property name="jakarta.persistence.jdbc.url"
-                value="jdbc:derby:db;create=true"/>
+      <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+      <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+      <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/optaplanner-persistence/optaplanner-persistence-jpa/src/test/resources/META-INF/persistence.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<persistence version="3.0" xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd">
+  <persistence-unit name="test" transaction-type="RESOURCE_LOCAL">
+    <class>org.optaplanner.persistence.jpa.impl.AbstractScoreJpaTest$AbstractTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.hardsoft.HardSoftScoreConverterTest$HardSoftScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScoreConverterTest$HardSoftBigDecimalScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScoreConverterTest$HardMediumSoftBigDecimalScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreConverterTest$HardMediumSoftLongScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.simple.SimpleScoreConverterTest$SimpleScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.bendable.BendableScoreConverterTest$BendableScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.hardsoftlong.HardSoftLongScoreConverterTest$HardSoftLongScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.simplelong.SimpleLongScoreConverterTest$SimpleLongScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.hardmediumsoft.HardMediumSoftScoreConverterTest$HardMediumSoftScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreConverterTest$BendableBigDecimalScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.bendablelong.BendableLongScoreConverterTest$BendableLongScoreConverterTestJpaEntity</class>
+    <class>org.optaplanner.persistence.jpa.api.score.buildin.simplebigdecimal.SimpleBigDecimalScoreConverterTest$SimpleBigDecimalScoreConverterTestJpaEntity</class>
+    <properties>
+      <property name="jakarta.persistence.schema-generation.database.action"
+                value="drop-and-create"/>
+      <property name="jakarta.persistence.jdbc.driver"
+                value="org.apache.derby.jdbc.EmbeddedDriver"/>
+      <property name="jakarta.persistence.jdbc.url"
+                value="jdbc:derby:db;create=true"/>
+    </properties>
+  </persistence-unit>
+</persistence>


### PR DESCRIPTION
Same as https://github.com/apache/incubator-kie-drools/pull/5764 but for OptaPlanner. The goal is to get rid of a transitive dependency on Hibernate, which is now licensed under LGPL 2.1, which is unwanted for ASF releases.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://apache.github.io/incubator-kie-optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
