### PR TITLE
kie-issues#1255: agent docker config in main pipeline

### DIFF
--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -42,3 +42,11 @@ seed:
     path: .ci/jenkins/config/branch.yaml
 jenkins:
   email_creds_id: OPTAPLANNER_CI_NOTIFICATION_EMAILS
+  agent:
+    docker:
+      builder:
+        # At some point, this image will need to be changed when a release branch is created
+        # but we need to make sure the image exists first ... simple tag before setting up the branch ?
+        # See https://github.com/kiegroup/kie-issues/issues/551
+        image: quay.io/kiegroup/kogito-ci-build:main-latest
+        args: --privileged --group-add docker


### PR DESCRIPTION
To properly fix
* apache/incubator-kie-issues#1255

Adding jenkins agent docker configuration to .ci/config/main.yaml

Also in:
* apache/incubator-kie-kogito-pipelines#1205
* apache/incubator-kie-drools#5971
* apache/incubator-kie-optaplanner#3094

There are jobs already in main pipeline (either root folder or defined in dsl/seed_job_branch.groovy file), which didn't have access to jenkins agent docker image and args configuration from branch.yaml - because that one is loaded only in Jenkinsfile.seed.branch - which did not make it possible to reference these values already in dsl/seed_job_branch.groovy.

So adding the agent docker configuration into main.yaml and loading already in Jenkinsfile.seed.main, so that all DSL jobs are able to use this value loaded from particular branch (except from the dsl/seed_job_main.groovy which is the actual first entry point into DSL generation and no docker config is needed there as of now).