### PR TITLE
kie-issues#1387: Adjust pipelines to use the gpg key provided by Apache to sign the artifacts

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -150,14 +150,9 @@ pipeline {
                             }
                         }
                         if (isRelease()) {
-                            release.gpgImportKeyFromFileWithPassword(getReleaseGpgSignKeyCredsId(), getReleaseGpgSignPassphraseCredsId())
-                            withCredentials([string(credentialsId: getReleaseGpgSignPassphraseCredsId(), variable: 'SIGNING_KEY_PASSWORD')]) {
-                                    mavenCommand.withProperty('gpg.passphrase', SIGNING_KEY_PASSWORD)
-                                    mavenCommand.withProfiles(['apache-release'])
-
-                                    mavenRunClosure()
-                                }
-                            }
+                            release.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
+                            mavenCommand.withProfiles(['apache-release'])
+                            mavenRunClosure()
                         } else {
                             mavenRunClosure()
                         }

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -87,8 +87,8 @@ cloud:
 release:
   gpg:
     sign:
-      key-credentials-id: 'asf-release-gpg-signing-key'
-      passphrase-credentials-id: 'asf-release-gpg-signing-key-passphrase'
+      key-credentials-id: 'GPG_KEY'
+      passphrase-credentials-id: ''
 jenkins:
   email_creds_id: OPTAPLANNER_CI_NOTIFICATION_EMAILS
   agent:

--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -48,5 +48,5 @@ jenkins:
         # At some point, this image will need to be changed when a release branch is created
         # but we need to make sure the image exists first ... simple tag before setting up the branch ?
         # See https://github.com/kiegroup/kie-issues/issues/551
-        image: quay.io/kiegroup/kogito-ci-build:main-latest
+        image: docker.io/apache/incubator-kie-kogito-ci-build:main-latest
         args: --privileged --group-add docker


### PR DESCRIPTION
Part of: https://github.com/apache/incubator-kie-issues/issues/1387