### PR TITLE
[10.0.x] Add productized maven property to the build command for the release job

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -146,7 +146,9 @@ pipeline {
 
                         if (isRelease()) {
                             releaseUtils.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
-                            mavenCommand.withProfiles(['apache-release'])
+                            mavenCommand
+                            .withProfiles(['apache-release'])
+                            .withProperty('productized')
                         }
 
                         configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]) {


### PR DESCRIPTION
This PR adds the `productized` property to the build command during a release to ensure reproducible builds.