### PR TITLE
CI duplicate maven configuration entries

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -66,7 +66,11 @@ buildchain_config:
     file_path: .ci/buildchain-config.yaml
     token_credentials_id: kie-ci3-token
 maven:
-  settings_file_id: kie-release-settings
+  settings:
+    nightly:
+      config_file_id: kie-nightly-settings
+    release:
+      config_file_id: kie-release-settings
   nexus:
     release_url: TO_DEFINE
     release_repository: TO_DEFINE
@@ -75,8 +79,12 @@ maven:
     build_promotion_profile_id: TO_DEFINE
   artifacts_repository: ''
   artifacts_upload_repository:
-    url: https://repository.apache.org/content/repositories/snapshots
-    creds_id: apache-nexus-kie-deploy-credentials
+    nightly:
+      url: https://repository.apache.org/content/repositories/snapshots
+      creds_id: apache-nexus-kie-deploy-credentials
+    release:
+      url: https://repository.apache.org/service/local/staging/deploy/maven2
+      creds_id: jenkins-deploy-to-nexus-staging
 cloud:
   image:
     registry_user_credentials_id: DOCKERHUB_USER

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -41,10 +41,10 @@ fi
 
 git_author="$(echo ${git_url} | awk -F"${git_server_url}" '{print $2}' | awk -F. '{print $1}'  | awk -F/ '{print $1}')"
 
-export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/optaplanner
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/incubator-kie-optaplanner
 export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/incubator-kie-optaplanner
 export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
-export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/optaplanner
+export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/incubator-kie-optaplanner
 
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h


### PR DESCRIPTION
Adjusting branch.yaml configuration to split maven related configurations for nightly and release.

Part of ensemble:

- apache/incubator-kie-kogito-pipelines#1259
- apache/incubator-kie-drools#6132
- apache/incubator-kie-optaplanner#3135
- apache/incubator-kie-optaplanner-quickstarts#635
- apache/incubator-kie-kogito-runtimes#3738
- apache/incubator-kie-kogito-apps#2121
- apache/incubator-kie-kogito-examples#2026

The scope of changes:

- maven settings.xml reference (config file id pointing at pre-defined config file in jenkins)
- artifacts upload repository
  - url - mostly informational, should not be needed for deploy itself (inheriting that configuration from apache parent)
  - credentials-id - the important part, allowing to configure different credentials for nightly and release.

Notes:
- in some places the configuration variants denoted as nightly are used in other places too (e.g. setup-branch).
