### PR TITLE
[kie-issues#1561] Remove productized profile for filtering out optaplanner-constraint-streams-bavet module.

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -265,7 +265,7 @@
               <configuration>
                 <rules>
                   <requireManagedDeps implementation="org.commonjava.maven.enforcer.rule.EnforceManagedDepsRule">
-                    <checkProfiles>false</checkProfiles>
+                    <checkProfiles>true</checkProfiles>
                     <failOnViolation>true</failOnViolation>
                   </requireManagedDeps>
                 </rules>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -265,7 +265,7 @@
               <configuration>
                 <rules>
                   <requireManagedDeps implementation="org.commonjava.maven.enforcer.rule.EnforceManagedDepsRule">
-                    <checkProfiles>true</checkProfiles>
+                    <checkProfiles>false</checkProfiles>
                     <failOnViolation>true</failOnViolation>
                   </requireManagedDeps>
                 </rules>

--- a/core/optaplanner-core/pom.xml
+++ b/core/optaplanner-core/pom.xml
@@ -57,6 +57,10 @@
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-constraint-drl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-constraint-streams-bavet</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -74,22 +78,5 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>default</id>
-      <activation>
-        <property>
-          <name>!productized</name>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.optaplanner</groupId>
-          <artifactId>optaplanner-constraint-streams-bavet</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,20 +49,7 @@
     <module>optaplanner-constraint-streams-common</module>
     <module>optaplanner-constraint-streams-drools</module>
     <module>optaplanner-constraint-drl</module>
+    <module>optaplanner-constraint-streams-bavet</module>
   </modules>
-
-  <profiles>
-    <profile>
-      <id>default</id>
-      <activation>
-        <property>
-          <name>!productized</name>
-        </property>
-      </activation>
-      <modules>
-        <module>optaplanner-constraint-streams-bavet</module>
-      </modules>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
Resolves https://github.com/apache/incubator-kie-issues/issues/1561

After discussion with Luca, we decided to remove the productized profile, as it is not needed anymore at the place where the optaplanner-constraint-streams-bavet is handled with it. 