### PR TITLE
[NO ISSUE] Bump version.org.springframework from 6.1.8 to 6.1.12

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -46,7 +46,7 @@
     <version.org.apache.logging.log4j>2.22.1</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.io.quarkiverse.operatorsdk>6.6.7</version.io.quarkiverse.operatorsdk>
-    <version.io.quarkus>3.15.3</version.io.quarkus>
+    <version.io.quarkus>3.15.3.1</version.io.quarkus>
     <version.io.netty>4.1.118.Final</version.io.netty>
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.11.0</version.org.apache.commons.text>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -58,7 +58,7 @@
     <version.org.jfree.jfreechart>1.5.4</version.org.jfree.jfreechart>
     <version.org.openrewrite.recipe>1.19.3</version.org.openrewrite.recipe>
     <version.org.slf4j>2.0.6</version.org.slf4j><!-- TODO keep in sync with quarkus-bom -->
-    <version.org.springframework>6.1.8</version.org.springframework>
+    <version.org.springframework>6.1.12</version.org.springframework>
     <version.org.springframework.boot>3.2.6</version.org.springframework.boot>
 
     <!-- ************************************************************************ -->

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -51,7 +51,7 @@
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.11.0</version.org.apache.commons.text>
     <version.org.apache.openjpa>4.0.0</version.org.apache.openjpa>
-    <version.org.apache.poi>5.4.1</version.org.apache.poi>
+    <version.org.apache.poi>5.2.3</version.org.apache.poi>
     <version.org.assertj>3.24.2</version.org.assertj>
     <version.org.freemarker>2.3.32</version.org.freemarker>
     <version.org.jdom2>2.0.6.1</version.org.jdom2>

--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -51,7 +51,7 @@
     <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
     <version.org.apache.commons.text>1.11.0</version.org.apache.commons.text>
     <version.org.apache.openjpa>4.0.0</version.org.apache.openjpa>
-    <version.org.apache.poi>5.2.3</version.org.apache.poi>
+    <version.org.apache.poi>5.4.1</version.org.apache.poi>
     <version.org.assertj>3.24.2</version.org.assertj>
     <version.org.freemarker>2.3.32</version.org.freemarker>
     <version.org.jdom2>2.0.6.1</version.org.jdom2>


### PR DESCRIPTION
FIX the [CVE-2024-38809](https://github.com/advisories/GHSA-2rmj-mq67-h97g)
[CVE-2024-38820](https://github.com/advisories/GHSA-4gc7-5j7h-4qph)